### PR TITLE
refactor(hash): needsRehash should return true when invalid identifier

### DIFF
--- a/src/drivers/argon.ts
+++ b/src/drivers/argon.ts
@@ -281,6 +281,7 @@ export class Argon implements HashDriverContract {
    * 3. The memory value is changed
    * 4. The parellelism value is changed
    * 5. The argon variant is changed
+   * 6. The provided hash has not been hashed with argon
    *
    * ```ts
    * const isValid = await argon.verify(hash, plainText)
@@ -294,7 +295,7 @@ export class Argon implements HashDriverContract {
   needsReHash(value: string): boolean {
     const phcNode = this.#phcFormatter.deserialize(value)
     if (!this.#ids.includes(phcNode.id)) {
-      throw new TypeError('Value is not a valid argon hash')
+      return true
     }
 
     /**

--- a/src/drivers/bcrypt.ts
+++ b/src/drivers/bcrypt.ts
@@ -227,6 +227,7 @@ export class Bcrypt implements HashDriverContract {
    * 1. The bcrypt version is changed
    * 2. Number of rounds are changed
    * 3. Bcrypt hash is not using MCF hash format
+   * 4. The provided hash has not been hashed with bcrypt
    *
    * ```ts
    * const isValid = await bcrypt.verify(hash, plainText)
@@ -244,7 +245,7 @@ export class Bcrypt implements HashDriverContract {
 
     const phcNode = this.#phcFormatter.deserialize(value)
     if (phcNode.id !== 'bcrypt') {
-      throw new TypeError('Value is not a valid bcrypt hash')
+      return true
     }
 
     /**

--- a/src/drivers/scrypt.ts
+++ b/src/drivers/scrypt.ts
@@ -226,6 +226,7 @@ export class Scrypt implements HashDriverContract {
    * 1. The cost value is changed
    * 2. The blockSize value is changed
    * 3. The parallelization value is changed
+   * 4. The provided hash has not been hashed with scrypt
    *
    * ```ts
    * const isValid = await scrypt.verify(hash, plainText)
@@ -239,7 +240,7 @@ export class Scrypt implements HashDriverContract {
   needsReHash(value: string): boolean {
     const phcNode = this.#phcFormatter.deserialize(value)
     if (phcNode.id !== 'scrypt') {
-      throw new TypeError('Value is not a valid scrypt hash')
+      return true
     }
 
     /**

--- a/tests/drivers/argon2.spec.ts
+++ b/tests/drivers/argon2.spec.ts
@@ -414,7 +414,7 @@ test.group('argon | needsRehash', () => {
     )
   })
 
-  test('throw error when not a valid argon identifier', async ({ assert }) => {
+  test('return true when not a valid argon identifier', async ({ assert }) => {
     const hash =
       '$bcrypt$v=19$m=4096,t=3,p=1$PcEZHj1maR/+ZQynyJHWZg$2jEN4xcww7CYp1jakZB1rxbYsZ55XH2HgjYRtdZtubI'
 
@@ -426,7 +426,7 @@ test.group('argon | needsRehash', () => {
       saltSize: 16,
     })
 
-    await assert.rejects(() => argon.needsReHash(hash), 'Value is not a valid argon hash')
+    assert.isTrue(argon.needsReHash(hash))
   })
 
   test('return true when using argon2 directly', async ({ assert }) => {

--- a/tests/drivers/bcrypt.spec.ts
+++ b/tests/drivers/bcrypt.spec.ts
@@ -236,13 +236,13 @@ test.group('bcrypt | needsRehash', () => {
     )
   })
 
-  test('throw error when identifier is invalid', async ({ assert }) => {
+  test('return true when not a valid bcrypt identifier', async ({ assert }) => {
     const bcrypt = new Bcrypt({
       rounds: 10,
     })
 
     const hash = '$argon2id$v=98$r=10$Jtxi46WJ26OQ0khsYLLlnw$knXGfuRFsSjXdj88JydPOnUIglvm1S8'
-    await assert.rejects(() => bcrypt.needsReHash(hash), 'Value is not a valid bcrypt hash')
+    assert.isTrue(bcrypt.needsReHash(hash))
   })
 })
 

--- a/tests/drivers/scrypt.spec.ts
+++ b/tests/drivers/scrypt.spec.ts
@@ -306,15 +306,13 @@ test.group('scrypt | needsRehash', () => {
     await assert.rejects(() => scrypt.needsReHash('foo'), 'pchstr must contain a $ as first char')
   })
 
-  test('throw error when identifier is invalid', async ({ assert }) => {
+  test('return true when not a valid scrypt identifier', async ({ assert }) => {
     const scrypt = new Scrypt({
       cost: 16384,
     })
 
-    const hash =
-      '$script$n=16384,r=8,p=1$YhdCGu1G+vTC6F9oJZ16lg$IDWTbizFCq5n9YvPiy3YTPdUD12Nf1Iit8aQeGyWZdA9k9L8rKk9Ii5jQxSkV0MJyxr3/nzOHh+VTht0KFxiBA'
-
-    await assert.rejects(() => scrypt.needsReHash(hash), 'Value is not a valid scrypt hash')
+    const hash = '$argon2id$v=98$r=10$Jtxi46WJ26OQ0khsYLLlnw$knXGfuRFsSjXdj88JydPOnUIglvm1S8'
+    assert.isTrue(scrypt.needsReHash(hash))
   })
 })
 


### PR DESCRIPTION
Hey there! 👋🏻 

This PR makes a **breaking change** to the `needsRehash` method.

Before, passing an invalid variant throws an error. Now, the method will return `true`.

**Why has this change been done?**

First, it makes sense to return `true` if the value has been hashed with another driver (or if the hash does not match the correct format). This allows us to swap the hashing algorithm easily.

Secondly, we mimic how PHP does it.

```php
<?php

$a = '123';
$hash = password_hash($a, PASSWORD_BCRYPT, ['cost' => 16]);
var_dump(password_needs_rehash($hash, PASSWORD_ARGON2I)); // bool(true)
var_dump(password_needs_rehash('asdb', PASSWORD_ARGON2I)); // bool(true)
```
