### PR TITLE
fix(argond2id):reordering parameters order during serialization to ma…

### DIFF
--- a/src/drivers/argon.ts
+++ b/src/drivers/argon.ts
@@ -222,8 +222,8 @@ export class Argon implements HashDriverContract {
       id: `argon2${this.#config.variant}`,
       version: this.#config.version,
       params: {
-        t: this.#config.iterations,
         m: this.#config.memory,
+        t: this.#config.iterations,
         p: this.#config.parallelism,
       },
     })

--- a/tests/drivers/argon2.spec.ts
+++ b/tests/drivers/argon2.spec.ts
@@ -220,6 +220,42 @@ test.group('argon | verify', () => {
     assert.isTrue(await argon.verify(hash, 'password'))
   })
 
+  test('should verify a precomputed hash with old parameters order', async ({ assert }) => {
+    // Precomputed hash for "password"
+    const hash =
+      '$argon2id$v=19$t=4,m=65536,p=1$oNZeAqWynNAkeJUGcuNMSw$O47kb/ayyV1VWoQLDpI/IkDOYUCF/Ctqzxys4cyEeGc'
+
+    const argon = new Argon({
+      variant: 'id',
+      iterations: 4,
+      memory: 65536,
+      parallelism: 1,
+      version: 19,
+      saltSize: 16,
+      hashLength: 32,
+    })
+
+    assert.isTrue(await argon.verify(hash, 'test-124_arg'))
+  })
+
+  test('should verify a precomputed hash with new parameters order', async ({ assert }) => {
+    // Precomputed hash for "password"
+    const hash =
+      '$argon2id$v=19$m=65536,t=4,p=1$oNZeAqWynNAkeJUGcuNMSw$O47kb/ayyV1VWoQLDpI/IkDOYUCF/Ctqzxys4cyEeGc'
+
+    const argon = new Argon({
+      variant: 'id',
+      iterations: 4,
+      memory: 65536,
+      parallelism: 1,
+      version: 19,
+      saltSize: 16,
+      hashLength: 32,
+    })
+
+    assert.isTrue(await argon.verify(hash, 'test-124_arg'))
+  })
+
   test('fail verification when value is formatted as phc string', async ({ assert }) => {
     const argon = new Argon({
       variant: 'id',


### PR DESCRIPTION
…tch phc standard

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

https://github.com/adonisjs/hash/issues/12
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves https://github.com/adonisjs/hash/issues/12 

Reordeing parameters order of argon2id hash during serialization process to match this line of phc standard : 
"The parameters shall appear in the m,t,p,keyid,data order."
https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md

and to resolve compatibility issue with other tools described on the above issue

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

### Tests 
All tests passed
![image](https://github.com/user-attachments/assets/831beda4-f993-499b-94b9-6cc0af840bce)

