### PR TITLE
fix(argon): #variants to rely on argon2 exports

### DIFF
--- a/src/drivers/argon.ts
+++ b/src/drivers/argon.ts
@@ -8,6 +8,7 @@
  */
 
 import type argon2 from 'argon2'
+import { argon2i, argon2d, argon2id } from 'argon2'
 import { safeEqual } from '@poppinss/utils'
 
 import { PhcFormatter } from '../phc_formatter.js'
@@ -55,9 +56,9 @@ export class Argon implements HashDriverContract {
    * Supported variants
    */
   #variants: { [K in ArgonVariants]: 0 | 1 | 2 } = {
-    i: 0,
-    d: 1,
-    id: 2,
+    i: argon2i,
+    d: argon2d,
+    id: argon2id,
   }
 
   /**

--- a/tests/drivers/argon2.spec.ts
+++ b/tests/drivers/argon2.spec.ts
@@ -203,7 +203,7 @@ test.group('argon | verify', () => {
     assert.isTrue(matches)
   })
 
-  test('should verify a precomputed hash', async ({ assert }) => {
+  test('should verify a precomputed hash for variant id', async ({ assert }) => {
     // Precomputed hash for "password"
     const hash =
       '$argon2id$v=19$m=4096,t=3,p=1$PcEZHj1maR/+ZQynyJHWZg$2jEN4xcww7CYp1jakZB1rxbYsZ55XH2HgjYRtdZtubI'
@@ -220,8 +220,42 @@ test.group('argon | verify', () => {
     assert.isTrue(await argon.verify(hash, 'password'))
   })
 
-  test('should verify a precomputed hash with old parameters order', async ({ assert }) => {
+  test('should verify a precomputed hash for variant i', async ({ assert }) => {
     // Precomputed hash for "password"
+    const hash =
+      '$argon2i$v=19$m=4096,t=4,p=2$dHRHRnJrNXhMS3hGdXp2Sg$rjAqTHriWP3GhO5/ZYoxuKcXDks/02JLGld9uBTsUgc'
+
+    const argon = new Argon({
+      variant: 'i',
+      iterations: 4,
+      memory: 4096,
+      parallelism: 2,
+      version: 19,
+      saltSize: 16,
+    })
+
+    assert.isTrue(await argon.verify(hash, 'password'))
+  })
+
+  test('should verify a precomputed hash for variant d', async ({ assert }) => {
+    // Precomputed hash for "password"
+    const hash =
+      '$argon2d$v=19$m=4096,t=4,p=2$dHRHRnJrNXhMS3hGdXp2Sg$F4lQNEt3xXSCNwTOflBJPzSlNk9dN3h1+lizNakqEzs'
+
+    const argon = new Argon({
+      variant: 'd',
+      iterations: 4,
+      memory: 4096,
+      parallelism: 2,
+      version: 19,
+      saltSize: 16,
+    })
+
+    assert.isTrue(await argon.verify(hash, 'password'))
+  })
+
+  test('should verify a precomputed hash with old parameters order', async ({ assert }) => {
+    // Precomputed hash for "test-124_arg"
     const hash =
       '$argon2id$v=19$t=4,m=65536,p=1$oNZeAqWynNAkeJUGcuNMSw$O47kb/ayyV1VWoQLDpI/IkDOYUCF/Ctqzxys4cyEeGc'
 
@@ -239,7 +273,7 @@ test.group('argon | verify', () => {
   })
 
   test('should verify a precomputed hash with new parameters order', async ({ assert }) => {
-    // Precomputed hash for "password"
+    // Precomputed hash for "test-124_arg"
     const hash =
       '$argon2id$v=19$m=65536,t=4,p=1$oNZeAqWynNAkeJUGcuNMSw$O47kb/ayyV1VWoQLDpI/IkDOYUCF/Ctqzxys4cyEeGc'
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/adonisjs/hash/issues/16

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Changes:

- update argon.ts to rely on argon2 exports to define variants values
- add tests to cover each individual variant
- update test comment to reflect the correct value 

<!-- Why is this change required? What problem does it solve? -->

Why:

Currently, variants don't match [argon2 lib](https://github.com/ranisalt/node-argon2/blob/master/argon2.cjs#L13), so when trying to verify `i` or `d`, it will fail.
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves https://github.com/adonisjs/hash/issues/16

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
